### PR TITLE
Dockerfile の LANG 環境変数を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   && localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
 RUN yarn global add htpasswd@2.4.6
 
-ENV LANG ja_JP.utf8
+ENV LANG=ja_JP.UTF-8
 ENV TZ=Asia/Tokyo
 
 WORKDIR /app


### PR DESCRIPTION
https://github.com/progedu/intro-2024-edition/pull/1753 関連

`ENV LANG ja_JP.utf8` の部分を `ENV LANG=ja_JP.UTF-8` に統一しました